### PR TITLE
[In-the-wild Faces Dataset] Removing `alpha` channel in `load_image()`

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -88,10 +88,8 @@ def load_image(
     if is_gray:
         image = imread(image_path, flatten=True).astype(np.float32)
     else:
-        image = imread(image_path).astype(np.float32)
+        image = imread(image_path, mode="RGB").astype(np.float32)
     image = imresize(image, [image_size, image_size])
-    if image.shape != (image_size,image_size,3):
-        image = image[:, :, :3].copy()  # try removing the alpha channel
     image = image.astype(np.float32) * (image_value_range[-1] - image_value_range[0]) / 255.0 + image_value_range[0]
     return image
 

--- a/ops.py
+++ b/ops.py
@@ -89,7 +89,7 @@ def load_image(
         image = imread(image_path, flatten=True).astype(np.float32)
     else:
         image = imread(image_path).astype(np.float32)
-    image = imresize(image, [image_size, image_size, 3])
+    image = imresize(image, [image_size, image_size])
     if image.shape != (image_size,image_size,3):
         image = image[:, :, :3].copy()  # try removing the alpha channel
     image = image.astype(np.float32) * (image_value_range[-1] - image_value_range[0]) / 255.0 + image_value_range[0]

--- a/ops.py
+++ b/ops.py
@@ -89,7 +89,9 @@ def load_image(
         image = imread(image_path, flatten=True).astype(np.float32)
     else:
         image = imread(image_path).astype(np.float32)
-    image = imresize(image, [image_size, image_size])
+    image = imresize(image, [image_size, image_size, 3])
+    if image.shape != (image_size,image_size,3):
+        image = image[:, :, :3].copy()  # try removing the alpha channel
     image = image.astype(np.float32) * (image_value_range[-1] - image_value_range[0]) / 255.0 + image_value_range[0]
     return image
 


### PR DESCRIPTION
Training failing on `In-the-wild Faces` dataset which you can find the download link in the Datasets section of this site (https://susanqq.github.io/UTKFace/)

The error message I saw was as follows:
```
could not broadcast input array from shape (128,128,3) into shape (128,128)
```

This error could potentially result from `load_image` returning a M * N * 4 matrix if there is a RGBA image in the batch.